### PR TITLE
Adding directory skip

### DIFF
--- a/calculate/calculator.go
+++ b/calculate/calculator.go
@@ -58,7 +58,7 @@ func (c *Calculator) calculateSourceFileHash(sourceFile *blaze_query.SourceFile)
 	// Open the file for use
 	file, err := os.Open(fileAbsPath)
 	if err != nil {
-		log.Printf("Failed to open %s", fileAbsPath)
+		log.Info("Skipping target: Failed to open %s", fileAbsPath)
 		c.LabelCache[sourceFile.GetName()] = ""
 		return ""
 	}
@@ -67,7 +67,7 @@ func (c *Calculator) calculateSourceFileHash(sourceFile *blaze_query.SourceFile)
 	// skip if the file is a directory
 	info, err := os.Stat(fileAbsPath)
 	if info.IsDir() {
-		log.Printf("Target %s is a directory.", fileAbsPath)
+		log.Info("Skipping target: Target is a directory %s", fileAbsPath)
 		c.LabelCache[sourceFile.GetName()] = ""
 		return ""
 	}
@@ -92,7 +92,7 @@ func (c *Calculator) calculateInputHash(label string) string {
 	target, exists := c.LabelTargets[label]
 
 	if !exists {
-		log.Printf("Did not find target with label %s", label)
+		log.Info("Skipping target: Did not find target with label %s", label)
 		return ""
 	}
 

--- a/calculate/calculator.go
+++ b/calculate/calculator.go
@@ -58,7 +58,7 @@ func (c *Calculator) calculateSourceFileHash(sourceFile *blaze_query.SourceFile)
 	// Open the file for use
 	file, err := os.Open(fileAbsPath)
 	if err != nil {
-		log.Info("Skipping target: Failed to open %s", fileAbsPath)
+		fmt.Fprintf(os.Stdout, "Skipping empty target: Failed to open %s", fileAbsPath)
 		c.LabelCache[sourceFile.GetName()] = ""
 		return ""
 	}
@@ -67,7 +67,7 @@ func (c *Calculator) calculateSourceFileHash(sourceFile *blaze_query.SourceFile)
 	// skip if the file is a directory
 	info, err := os.Stat(fileAbsPath)
 	if info.IsDir() {
-		log.Info("Skipping target: Target is a directory %s", fileAbsPath)
+		fmt.Fprintf(os.Stdout, "Skipping empty target: Target is a directory %s", fileAbsPath)
 		c.LabelCache[sourceFile.GetName()] = ""
 		return ""
 	}
@@ -92,7 +92,7 @@ func (c *Calculator) calculateInputHash(label string) string {
 	target, exists := c.LabelTargets[label]
 
 	if !exists {
-		log.Info("Skipping target: Did not find target with label %s", label)
+		fmt.Fprintf(os.Stdout, "Skipping empty target: Did not find target with label %s", label)
 		return ""
 	}
 

--- a/calculate/calculator.go
+++ b/calculate/calculator.go
@@ -64,6 +64,14 @@ func (c *Calculator) calculateSourceFileHash(sourceFile *blaze_query.SourceFile)
 	}
 	defer file.Close()
 
+	// skip if the file is a directory
+	info, err := os.Stat(fileAbsPath)
+	if info.IsDir() {
+		log.Printf("Target %s is a directory.", fileAbsPath)
+		c.LabelCache[sourceFile.GetName()] = ""
+		return ""
+	}
+	
 	checksum := sha256.New()
 	if _, err := io.Copy(checksum, file); err != nil {
 		log.Panicf("Failed to get checksum of %s", fileAbsPath)

--- a/calculate/query.go
+++ b/calculate/query.go
@@ -23,7 +23,11 @@ func GetQueryResult(workspacePath, bazel, query string) *blaze_query.QueryResult
 	err := command.Run()
 
 	if err != nil {
-		log.Println("Failed to run query")
+		log.Println("Failed to run query with error: %s", err)
+		log.Println("Args: %s", args)
+		log.Println("bazel exec: %s", bazel)
+		log.Println("context: %s", ctx)
+		log.Println("query: %s", query)
 		log.Println("Stdout:")
 		log.Println(string(stdoutBuffer.Bytes()))
 		log.Println("Stderr:")

--- a/cmd/calculate.go
+++ b/cmd/calculate.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"path"
-
 	"github.com/purkhusid/biff/calculate"
 	"github.com/spf13/cobra"
 )

--- a/cmd/calculate.go
+++ b/cmd/calculate.go
@@ -38,6 +38,6 @@ var calculateCmd = &cobra.Command{
 		calculator := calculate.NewCalculator(queryResult)
 		hashedTargets := calculator.CalculateHashes()
 
-		calculate.WriteResultsToFile(hashedTargets, path.Join(workspacePath, calculateOutputPathFlag))
+		calculate.WriteResultsToFile(hashedTargets, calculateOutputPathFlag)
 	},
 }


### PR DESCRIPTION
This PR adds a few changes required for our bazel + CI setup. This includes:

- Uses full path for the `calculate` out json file, rather than relative path
- Fixes a problem where a target that was an empty directory could not generate a checksum
- Switches soft fail log warnings to stdout rather than stderr for simpler scripting output
- Some additional debugging lines on failed commands